### PR TITLE
FIX: Avoid accessing site.mobileView during initialization

### DIFF
--- a/javascripts/discourse/api-initializers/init-mobile-title-header-switch.gjs
+++ b/javascripts/discourse/api-initializers/init-mobile-title-header-switch.gjs
@@ -12,23 +12,23 @@ function getMobileSwitchTitle() {
 }
 
 export default apiInitializer((api) => {
-  if (!api.container.lookup("service:site").mobileView) {
-    return;
-  }
-
-  if (!getMobileSwitchTitle()) {
-    api.modifyClass(
-      "service:header",
-      (Superclass) =>
-        class extends Superclass {
-          get topicInfoVisible() {
+  api.modifyClass(
+    "service:header",
+    (Superclass) =>
+      class extends Superclass {
+        get topicInfoVisible() {
+          if (this.site.mobileView && !getMobileSwitchTitle()) {
             return false;
           }
+          return super.topicInfoVisible;
         }
-    );
-  }
+      }
+  );
 
-  api.getCurrentUser().mobileSwitchTitle = getMobileSwitchTitle();
+  const currentUser = api.getCurrentUser();
+  if (currentUser) {
+    currentUser.mobileSwitchTitle = getMobileSwitchTitle();
+  }
 
   api.modifyClass(
     "controller:preferences/interface",


### PR DESCRIPTION
Move the mobile-view check 'just in time', and also fixes the current-user logic so it doesn't throw an error for anonymous users.